### PR TITLE
fix lag between users when adding/deleting cells

### DIFF
--- a/client/src/Notebook.jsx
+++ b/client/src/Notebook.jsx
@@ -32,15 +32,20 @@ const Notebook = ({ roomID }) => {
   useEffect(() => {
     if (ydocRef.current) {
       const cells = ydocRef.current.getArray('cells');
-      console.log(cells);
       setCells(cells);
       setCellsJSON(cells.toJSON());
+
+      // Listen to YJS events on the cells to fix the race issue where the UI updates before the YDoc finishes updating
+      cells.observeDeep(() => {
+        setCells(cells);
+        setCellsJSON(cells.toJSON());
+      });
     }
   }, [ydocRef.current]);
 
   useEffect(() => {
     if (!ydocRef.current) {
-      ydocRef.current = initializeYDoc(roomID);
+      ydocRef.current = initializeYDoc();
       roomToYDocMap.set(roomID, ydocRef.current);
     }
 


### PR DESCRIPTION
Adding `cells.observeDeep` fixes the race issue where the UI updates before the YDoc finishes updating. By adding it to the useEffect, any addition or deletion from the cells array causes react to refresh the state for all users.

First `useEffect` block In `Notebook.jsx`:
```
useEffect(() => {
    if (ydocRef.current) {
      const cells = ydocRef.current.getArray('cells');
      setCells(cells);
      setCellsJSON(cells.toJSON());

      
      cells.observeDeep(() => {
        setCells(cells);
        setCellsJSON(cells.toJSON());
      });
    }
  }, [ydocRef.current]);
  ```

