### PR TITLE
initialize output state to outputMap with useState in CodeCell

### DIFF
--- a/client/src/CodeCell.jsx
+++ b/client/src/CodeCell.jsx
@@ -12,7 +12,7 @@ const CodeCell = ({ cellID, roomID, cell, ytext }) => {
   const editorRef = useRef(null);
   const outputMap = cell.get('outputMap');
   const [processing, setProcessing] = useState(false);
-  const [output, setOutput] = useState('');
+  const [output, setOutput] = useState(outputMap);
   const [editorHeight, setEditorHeight] = useState('5vh');
 
   const handleEditorDidMount = (editor, monaco) => {


### PR DESCRIPTION
Output can now be shared with new collaborates who join a room with existing outputs from previously run cells