### PR TITLE
fix editor height to auto-increment line count with content

### DIFF
--- a/client/src/CodeCell.jsx
+++ b/client/src/CodeCell.jsx
@@ -21,6 +21,11 @@ const CodeCell = ({ cellID, roomID, cell, ytext }) => {
     const lineHeight = editor.getOption(monaco.editor.EditorOption.lineHeight);
     const lineCount = editor.getModel().getLineCount();
     setEditorHeight(`${lineCount * lineHeight}px`);
+
+    editor.onDidChangeModelContent(e => {
+      const lineCount = editor.getModel().getLineCount();
+      setEditorHeight(`${lineCount * lineHeight}px`);
+    });
   };
 
   useEffect(() => {
@@ -32,7 +37,7 @@ const CodeCell = ({ cellID, roomID, cell, ytext }) => {
     }
   }, [outputMap]);
 
-  const parseDreddResponse = (response) => {
+  const parseDreddResponse = response => {
     console.log(response);
     return response[0].output;
   };


### PR DESCRIPTION
Added this block inside of `handleEditorDidMount` for the CodeCell to auto-expand with content:

```js
  editor.onDidChangeModelContent(e => {
      const lineCount = editor.getModel().getLineCount();
      setEditorHeight(`${lineCount * lineHeight}px`);
    });
 ```