### PR TITLE
added toolbar at top to add cells to 0-index

### DIFF
--- a/client/src/components/Cells/Cells.jsx
+++ b/client/src/components/Cells/Cells.jsx
@@ -31,6 +31,7 @@ const Cells = ({ roomID, cells, setCells }) => {
 
   return (
     <Box sx={{ mx: 5, py: 1, width: '100%' }}>
+      <AddCell index={-1} />
       <Typography variant='h5' sx={{ textAlign: 'center', my: '40px', opacity: 0.7 }}></Typography>
       <DragDropContext onDragEnd={onDragEnd}>
         <Droppable droppableId='cells'>
@@ -60,7 +61,7 @@ const Cells = ({ roomID, cells, setCells }) => {
           )}
         </Droppable>
       </DragDropContext>
-      {cells && cells.length === 0 && <AddCell index={0} />}
+      {/* {cells && cells.length === 0 && <AddCell index={0} />} */}
     </Box>
   );
 };


### PR DESCRIPTION
ok, same as last attempt, now mergable to main instead of v0.1.2

I added one line in Cells.jsx to enable user to add cell to 0th index (at top of page), previously after first cell added only had ability to add to index 1 or below,

i tested it, but please test...