### PR TITLE
silent cleanup of client state without displaying alert message

### DIFF
--- a/src/components/Notebook/Notebook.tsx
+++ b/src/components/Notebook/Notebook.tsx
@@ -65,8 +65,8 @@ const Notebook = ({ docID, resourceTitle }: NotebookProps) => {
       if (provider) {
         updateDisconnectedClient(provider);
       }
-      e.preventDefault();
-      e.returnValue = '';
+      // e.preventDefault();
+      // e.returnValue = '';
     };
 
     window.addEventListener('beforeunload', handleBeforeUnload);


### PR DESCRIPTION
Instead of showing an alert to the user, allow silent clean up of client's state when the page is unloaded. That way, the inaccurate alert message "Changes may not be saved" is not displayed to the user prior to closing the browser tab.

**Changes**: commented out `e.preventDefault` and `e.returnValue = ''`

```tsx
  useEffect(() => {
    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
      if (provider) {
        updateDisconnectedClient(provider);
      }
      // e.preventDefault(); 
      // e.returnValue = '';
    };

    window.addEventListener('beforeunload', handleBeforeUnload);

    return () => {
      window.removeEventListener('beforeunload', handleBeforeUnload);
    };
  }, [provider]);

```